### PR TITLE
Remove @Dependent annotation for MP Rest Client

### DIFF
--- a/finish/src/main/java/io/openliberty/guides/inventory/client/SystemClient.java
+++ b/finish/src/main/java/io/openliberty/guides/inventory/client/SystemClient.java
@@ -25,7 +25,7 @@ import org.eclipse.microprofile.rest.client.annotation.RegisterProvider;
 import org.eclipse.microprofile.rest.client.inject.RegisterRestClient;
 
 // tag::annotations[]
-@Dependent
+
 @RegisterRestClient
 @RegisterProvider(ExceptionMapper.class)
 @Path("/properties")

--- a/start/src/main/java/io/openliberty/guides/inventory/client/SystemClient.java
+++ b/start/src/main/java/io/openliberty/guides/inventory/client/SystemClient.java
@@ -25,7 +25,7 @@ import org.eclipse.microprofile.rest.client.annotation.RegisterProvider;
 import org.eclipse.microprofile.rest.client.inject.RegisterRestClient;
 
 // tag::annotations[]
-@Dependent
+
 @RegisterRestClient
 @RegisterProvider(ExceptionMapper.class)
 @Path("/properties")


### PR DESCRIPTION
With the MP Rest Client 1.1 update, it is no longer necessary to add the @dependent annotation (or any scope annotation) to the Rest Client interface for CDI to recognize and process it because @RegisterRestClient is now a bean-defining annotation.