### PR TITLE
add grep command

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -373,7 +373,7 @@ calling the **system** service.
 
 To see the application metrics, run the following curl commmand. This command will Log in using **admin** user, and you will have to enter **adminpwd** as the password.
 ```
-curl -k -u admin https://localhost:9443/metrics/base
+curl -k -u admin https://localhost:9443/metrics/base | grep _ft_
 ```
 {: codeblock}
 
@@ -480,7 +480,7 @@ endif::[]
 ifdef::cloud-hosted[]
 Run the following curl command again and enter **adminpwd** as the password:
 ```
-curl -k -u admin https://localhost:9443/metrics/base
+curl -k -u admin https://localhost:9443/metrics/base | grep _ft_
 ```
 {: codeblock}
 


### PR DESCRIPTION
 add the `| grep _ft_` after the curl metrics commands, so that users can easily see the output that only shows the fault tolerance metrics