### PR TITLE
Fix for failing test-app check in MP6 update PR

### DIFF
--- a/scripts/testApp.sh
+++ b/scripts/testApp.sh
@@ -30,7 +30,7 @@ mvn liberty:start
 
 curl http://localhost:9080/inventory/systems/localhost
 
-COUNT=$(curl -k -u admin:adminpwd https://localhost:9443/metrics/base | wc -l)
+COUNT=$(curl -k -u admin:adminpwd https://localhost:9443/metrics?scope=base | wc -l)
 
 mvn -Dhttp.keepAlive=false \
     -Dmaven.wagon.http.pool=false \


### PR DESCRIPTION
Failed due to new REST endpoint in metrics which had to be changed in the testapp.sh
